### PR TITLE
merge main in add-worker

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,29 @@
+name: Build
+
+on:
+  push:
+  pull_request:
+
+jobs:
+  build-root:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+      - run: npm install
+      - run: npm run build
+
+  build-worker:
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: worker
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+      - run: npm install
+      - run: npm run build


### PR DESCRIPTION
This pull request adds a new GitHub Actions workflow to automate the build process for the project. The workflow includes separate jobs for building the root project and the worker directory.

### Build automation:

* `.github/workflows/build.yml`: Introduced a new workflow named `Build` that triggers on `push` and `pull_request` events. It includes two jobs:
  - [`build-root`](diffhunk://#diff-5c3fa597431eda03ac3339ae6bf7f05e1a50d6fc7333679ec38e21b337cb6721R1-R29): Sets up Node.js version 20, installs dependencies, and runs the build command for the root project.
  - [`build-worker`](diffhunk://#diff-5c3fa597431eda03ac3339ae6bf7f05e1a50d6fc7333679ec38e21b337cb6721R1-R29): Configures the working directory to `worker`, sets up Node.js version 20, installs dependencies, and runs the build command for the worker directory.